### PR TITLE
Set list selection highlight color to green

### DIFF
--- a/SystemInformer/settings.c
+++ b/SystemInformer/settings.c
@@ -251,7 +251,8 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"ThemeWindowForegroundColor", L"1c1c1c"); // RGB(28, 28, 28)
     PhpAddIntegerSetting(L"ThemeWindowBackgroundColor", L"2b2b2b"); // RGB(43, 43, 43)
     PhpAddIntegerSetting(L"ThemeWindowBackground2Color", L"414141"); // RGB(65, 65, 65)
-    PhpAddIntegerSetting(L"ThemeWindowHighlightColor", L"808080"); // RGB(128, 128, 128)
+    // Default highlight color for selected list items
+    PhpAddIntegerSetting(L"ThemeWindowHighlightColor", L"00ff00"); // RGB(0, 255, 0)
     PhpAddIntegerSetting(L"ThemeWindowHighlight2Color", L"8f8f8f"); // RGB(143, 143, 143)
     PhpAddIntegerSetting(L"ThemeWindowTextColor", L"ffffff"); // RGB(255, 255, 255)
     PhpAddIntegerSetting(L"ThinRows", L"0");

--- a/phlib/extlv.c
+++ b/phlib/extlv.c
@@ -302,6 +302,8 @@ LRESULT CALLBACK PhpExtendedListViewWndProc(
                                 if (selected)
                                 {
                                     customDraw->clrText = PhThemeWindowTextColor;
+                                    // Set highlight background to the theme highlight color
+                                    customDraw->clrTextBk = PhThemeWindowHighlightColor;
                                 }
                                 else if (colorChanged)
                                 {

--- a/phlib/theme.c
+++ b/phlib/theme.c
@@ -165,7 +165,9 @@ HBRUSH PhThemeWindowBackgroundBrush = NULL;
 COLORREF PhThemeWindowForegroundColor = RGB(28, 28, 28);
 COLORREF PhThemeWindowBackgroundColor = RGB(43, 43, 43);
 COLORREF PhThemeWindowBackground2Color = RGB(65, 65, 65);
-COLORREF PhThemeWindowHighlightColor = RGB(128, 128, 128);
+// Default highlight color used across controls (e.g. list selections)
+// Changed from grey to green
+COLORREF PhThemeWindowHighlightColor = RGB(0, 255, 0);
 COLORREF PhThemeWindowHighlight2Color = RGB(143, 143, 143);
 COLORREF PhThemeWindowTextColor = RGB(255, 255, 255);
 


### PR DESCRIPTION
## Summary
- tweak default theme highlight color to bright green
- store new highlight color in settings
- apply highlight color when list items are selected

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873739c4e708326b133ca63c3efe4a9